### PR TITLE
Fix Url being printed with non-encoded spaces

### DIFF
--- a/orchestration/scripts/Invoke-Helper.ps1
+++ b/orchestration/scripts/Invoke-Helper.ps1
@@ -673,9 +673,9 @@ function Show-ManagementGroupInfo {
     $parTopLevelManagementGroupName = $parParameters.parTopLevelManagementGroupName.value
     $parDeploymentSuffix = $parParameters.parDeploymentSuffix.value
     $varTenantId = (Get-AzTenant).Id
-    $varMgName = $parTopLevelManagementGroupName -replace ' ', '%20'
     $varManagementGroupLink = "$varAzPortalLink/#view/Microsoft_Azure_ManagementGroups/ManagmentGroupDrilldownMenuBlade/~/overview/tenantId/$varTenantId"
-    $varManagementGroupLink = "$varManagementGroupLink/mgId/$parDeploymentPrefix$parDeploymentSuffix/mgDisplayName/$varMgName/mgCanAddOrMoveSubscription~/true/mgParentAccessLevel/Owner/defaultMenuItemId/overview/drillDownMode~/true"
+    $varManagementGroupLink = "$varManagementGroupLink/mgId/$parDeploymentPrefix$parDeploymentSuffix/mgDisplayName/$parTopLevelManagementGroupName/mgCanAddOrMoveSubscription~/true/mgParentAccessLevel/Owner/defaultMenuItemId/overview/drillDownMode~/true"
+    $varManagementGroupLink = [System.Uri]::EscapeUriString($varManagementGroupLink)
     $varManagementGroupInfo = "If you want to learn more about your management group, please click following link.`n`n"
     $varManagementGroupInfo = "$varManagementGroupInfo$varManagementGroupLink`n`n"
 

--- a/orchestration/scripts/Invoke-Helper.ps1
+++ b/orchestration/scripts/Invoke-Helper.ps1
@@ -672,7 +672,7 @@ function Show-ManagementGroupInfo {
     $parDeploymentPrefix = $parParameters.parDeploymentPrefix.value
     $parTopLevelManagementGroupName = $parParameters.parTopLevelManagementGroupName.value
     $parDeploymentSuffix = $parParameters.parDeploymentSuffix.value
-    $varTenantId = (Get-AzTenant).Id
+    $varTenantId = (Get-AzContext).Tenant.Id
     $varManagementGroupLink = "$varAzPortalLink/#view/Microsoft_Azure_ManagementGroups/ManagmentGroupDrilldownMenuBlade/~/overview/tenantId/$varTenantId"
     $varManagementGroupLink = "$varManagementGroupLink/mgId/$parDeploymentPrefix$parDeploymentSuffix/mgDisplayName/$parTopLevelManagementGroupName/mgCanAddOrMoveSubscription~/true/mgParentAccessLevel/Owner/defaultMenuItemId/overview/drillDownMode~/true"
     $varManagementGroupLink = [System.Uri]::EscapeUriString($varManagementGroupLink)


### PR DESCRIPTION
# Overview/Summary

I've replaced the line using `-replace` with the function EscapeUriString for more robust URI encoding and replaced the command `(Get-AzTenant).Id`, which would return more than one tenant id, with the command `(Get-AzContext).Tenant.Id`, which only returns the tenant id of the tenant currently used.

## This PR fixes/adds/changes/removes

1. Fix output of Uri (Fixes #11)

